### PR TITLE
Add of heroku advanced configs, fix deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: MIX_ENV=prod elixir --sname caiquenator -S mix phx.server

--- a/compile
+++ b/compile
@@ -1,0 +1,10 @@
+# https://hexdocs.pm/phoenix/heroku.html#adding-the-phoenix-static-buildpack
+
+npm run deploy
+
+cd $phoenix_dir
+mix "${phoenix_ex}.digest"
+
+if mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; then
+  mix "${phoenix_ex}.digest.clean"
+fi

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,0 +1,1 @@
+compile="compile"


### PR DESCRIPTION
This PR assumes that the [`elixir-buildpack`](https://github.com/HashNuke/heroku-buildpack-elixir) and the [`phoenix-static-build`](https://github.com/gjaldon/heroku-buildpack-phoenix-static) were set via [the command line](https://devcenter.heroku.com/articles/buildpacks). e.g.

- `heroku buildpacks:add hashnuke/elixir`
- `heroku buildpacks:add https://github.com/gjaldon/heroku-buildpack-phoenix-static.git`


Overrides default `phoenix_static_builpack` compile script as it uses brunch and we are using webpack because of the `phoenix 1.4` upgrade in #21.

Also adds Procfile to define how the application can be started


